### PR TITLE
Use fread() return value to count bytes

### DIFF
--- a/dcc6502.c
+++ b/dcc6502.c
@@ -769,8 +769,8 @@ int main(int argc, char *argv[]) {
 
     byte_count = 0;
     while(!feof(input_file) && ((options.org + byte_count) <= 0xFFFFu) && (byte_count < options.max_num_bytes)) {
-        fread(&buffer[options.org + byte_count], 1, 1, input_file);
-        byte_count++;
+        size_t bytes_read = fread(&buffer[options.org + byte_count], 1, 1, input_file);
+        byte_count += bytes_read;
     }
 
     fclose(input_file);


### PR DESCRIPTION
Hello!

First of all, thanks for writing dcc6502! It looks pretty useful for NES homebrew development, especially on Linux.

I believe I have fixed a bug in dcc6502, and in the process also fixed the only warning emitted during the compilation of dcc6502.

I built the latest version of dcc6502 from source, on Ubuntu 16.04 LTS, using gcc 5.4.0.

This is the warning I was seeing when I first compiled the program:

$ make
gcc -o dcc6502 dcc6502.c -O
dcc6502.c: In function ‘main’:
dcc6502.c:772:9: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
         fread(&buffer[options.org + byte_count], 1, 1, input_file);
         ^

I also saw what looks like a bug, where dcc6502 was reporting an extra byte in the program it was disassembling, and printing out a phantom opcode that did not exist in the original.

My test input file consisted of only two bytes: 0xA9, and 0xFF. This corresponds to the instructions: LDA #$FF. The input file was generated manually with the following Python code:

#!/usr/bin/env python3
import sys
b = [0xA9, 0xFF]
sys.stdout.buffer.write(bytes(b))


Here is the xxd hex dump of the resulting file:
$ xxd lda-ff-example
00000000: a9ff                                     ..


Here is the output of dcc6502, built from the latest version (c003395dd7ab054340e88960515e22228e86d32a) on the master branch. Note that it says "File Size: 3", and lists an erroneous BRK opcode at address $8002:

$ ./dcc6502 lda-ff-example
; Source generated by DCC6502 version v2.1
; For more info about DCC6502, see https://github.com/tcarmelveilleux/dcc6502
; FILENAME: lda-ff-example, File Size: 3, ORG: $8000
;---------------------------------------------------------------------------
$8000   LDA #$FF        ;
$8002   BRK             ;


It turns out that the off by one file size is directly related to the fread() return values.

Previously, dcc6502 was calling fread() one byte at a time, and then incrementing a variable called byte_count. However, at least on my system, it seems that fread() didn't always return 1.

The code in this pull request captures the return value of fread(), and then increments byte_count by the returned value.

With this change, the compilation warning disappears. More importantly, dcc6502 now produces the expected output for my test file:

$ ./dcc6502 lda-ff-example
; Source generated by DCC6502 version v2.1
; For more info about DCC6502, see https://github.com/tcarmelveilleux/dcc6502
; FILENAME: lda-ff-example, File Size: 2, ORG: $8000
;---------------------------------------------------------------------------
$8000   LDA #$FF        ;